### PR TITLE
Linear legends and custom label formats

### DIFF
--- a/src/legend.js
+++ b/src/legend.js
@@ -29,12 +29,14 @@ d3_linearLegend: function (scale, cells, labelFormat) {
     i = 0;
 
     for (; i < cells; i++){
-      data.push(labelFormat(domain[0] + i*increment));
+      data.push(domain[0] + i*increment);
     }
   }
 
+  var labels = data.map(labelFormat);
+
   return {data: data,
-          labels: data,
+          labels: labels,
           feature: function(d){ return scale(d); }};
 },
 


### PR DESCRIPTION
Linear legends weren't working for me if I used a custom label format:

e.g.,

```
legend.labelFormat(d3.format('%'));
```

The labels were appearing fine, but the coloured boxes didn't have the right colour.

This fixes the problem for me.
